### PR TITLE
Fix big-endian binary stl reading

### DIFF
--- a/src/portable_endian.h
+++ b/src/portable_endian.h
@@ -1,12 +1,13 @@
-// portable_endian.h
-// from https://gist.github.com/panzi/6856583
-// "License": Public Domain
-// I, Mathias Panzenböck, place this file hereby into the public domain. Use it
-// at your own risk for whatever you like.  In case there are jurisdictions
-// that don't support putting things in the public domain you can also consider
-// it to be "dual licensed" under the BSD, MIT and Apache licenses, if you want
-// to. This code is trivial anyway. Consider it an example on how to get the
-// endian conversion functions on different platforms.
+/* portable_endian.h
+ * from https://gist.github.com/panzi/6856583
+ * "License": Public Domain
+ * I, Mathias Panzenböck, place this file hereby into the public domain. Use it
+ * at your own risk for whatever you like.  In case there are jurisdictions
+ * that don't support putting things in the public domain you can also consider
+ * it to be "dual licensed" under the BSD, MIT and Apache licenses, if you want
+ * to. This code is trivial anyway. Consider it an example on how to get the
+ * endian conversion functions on different platforms.
+ */
 
 #ifndef PORTABLE_ENDIAN_H__
 #define PORTABLE_ENDIAN_H__
@@ -64,7 +65,7 @@
 
 #elif defined(__WINDOWS__)
 
-//#	include <winsock2.h>
+/* #	include <winsock2.h> */
 #	include <sys/param.h>
 
 #	if BYTE_ORDER == LITTLE_ENDIAN

--- a/src/portable_endian.h
+++ b/src/portable_endian.h
@@ -1,0 +1,122 @@
+// portable_endian.h
+// from https://gist.github.com/panzi/6856583
+// "License": Public Domain
+// I, Mathias Panzenböck, place this file hereby into the public domain. Use it
+// at your own risk for whatever you like.  In case there are jurisdictions
+// that don't support putting things in the public domain you can also consider
+// it to be "dual licensed" under the BSD, MIT and Apache licenses, if you want
+// to. This code is trivial anyway. Consider it an example on how to get the
+// endian conversion functions on different platforms.
+
+#ifndef PORTABLE_ENDIAN_H__
+#define PORTABLE_ENDIAN_H__
+
+#if (defined(_WIN16) || defined(_WIN32) || defined(_WIN64)) && !defined(__WINDOWS__)
+
+#	define __WINDOWS__
+
+#endif
+
+#if defined(__linux__) || defined(__CYGWIN__)
+
+#	include <endian.h>
+
+#elif defined(__APPLE__)
+
+#	include <libkern/OSByteOrder.h>
+
+#	define htobe16(x) OSSwapHostToBigInt16(x)
+#	define htole16(x) OSSwapHostToLittleInt16(x)
+#	define be16toh(x) OSSwapBigToHostInt16(x)
+#	define le16toh(x) OSSwapLittleToHostInt16(x)
+ 
+#	define htobe32(x) OSSwapHostToBigInt32(x)
+#	define htole32(x) OSSwapHostToLittleInt32(x)
+#	define be32toh(x) OSSwapBigToHostInt32(x)
+#	define le32toh(x) OSSwapLittleToHostInt32(x)
+ 
+#	define htobe64(x) OSSwapHostToBigInt64(x)
+#	define htole64(x) OSSwapHostToLittleInt64(x)
+#	define be64toh(x) OSSwapBigToHostInt64(x)
+#	define le64toh(x) OSSwapLittleToHostInt64(x)
+
+#	define __BYTE_ORDER    BYTE_ORDER
+#	define __BIG_ENDIAN    BIG_ENDIAN
+#	define __LITTLE_ENDIAN LITTLE_ENDIAN
+#	define __PDP_ENDIAN    PDP_ENDIAN
+
+#elif defined(__OpenBSD__)
+
+#	include <sys/endian.h>
+
+#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+
+#	include <sys/endian.h>
+
+#	define be16toh(x) betoh16(x)
+#	define le16toh(x) letoh16(x)
+
+#	define be32toh(x) betoh32(x)
+#	define le32toh(x) letoh32(x)
+
+#	define be64toh(x) betoh64(x)
+#	define le64toh(x) letoh64(x)
+
+#elif defined(__WINDOWS__)
+
+//#	include <winsock2.h>
+#	include <sys/param.h>
+
+#	if BYTE_ORDER == LITTLE_ENDIAN
+
+#		define htobe16(x) htons(x)
+#		define htole16(x) (x)
+#		define be16toh(x) ntohs(x)
+#		define le16toh(x) (x)
+ 
+#		define htobe32(x) htonl(x)
+#		define htole32(x) (x)
+#		define be32toh(x) ntohl(x)
+#		define le32toh(x) (x)
+ 
+#		define htobe64(x) htonll(x)
+#		define htole64(x) (x)
+#		define be64toh(x) ntohll(x)
+#		define le64toh(x) (x)
+
+#	elif BYTE_ORDER == BIG_ENDIAN
+
+		/* that would be xbox 360 */
+#		define htobe16(x) (x)
+#		define htole16(x) __builtin_bswap16(x)
+#		define be16toh(x) (x)
+#		define le16toh(x) __builtin_bswap16(x)
+ 
+#		define htobe32(x) (x)
+#		define htole32(x) __builtin_bswap32(x)
+#		define be32toh(x) (x)
+#		define le32toh(x) __builtin_bswap32(x)
+ 
+#		define htobe64(x) (x)
+#		define htole64(x) __builtin_bswap64(x)
+#		define be64toh(x) (x)
+#		define le64toh(x) __builtin_bswap64(x)
+
+#	else
+
+#		error byte order not supported
+
+#	endif
+
+#	define __BYTE_ORDER    BYTE_ORDER
+#	define __BIG_ENDIAN    BIG_ENDIAN
+#	define __LITTLE_ENDIAN LITTLE_ENDIAN
+#	define __PDP_ENDIAN    PDP_ENDIAN
+
+#else
+
+#	error platform not supported
+
+#endif
+
+#endif

--- a/src/stlinit.c
+++ b/src/stlinit.c
@@ -256,15 +256,23 @@ void
 stl_read(stl_file *stl, int first_facet, int first) {
   stl_facet facet;
   int   i, j;
-  float *facet_floats[] = {
-    &facet.normal.x, &facet.normal.y, &facet.normal.z,
-    &facet.vertex[0].x, &facet.vertex[0].y, &facet.vertex[0].z,
-    &facet.vertex[1].x, &facet.vertex[1].y, &facet.vertex[1].z,
-    &facet.vertex[2].x, &facet.vertex[2].y, &facet.vertex[2].z
-  };
-  const int facet_float_length = sizeof(facet_floats) / sizeof(*facet_floats);
-  char facet_buffer[facet_float_length * sizeof(float)];
+  const int facet_float_length = 12;
+  float *facet_floats[12];
+  char facet_buffer[12 * sizeof(float)];
   uint32_t endianswap_buffer;  /* for byteswapping operations */
+
+  facet_floats[0] = &facet.normal.x;
+  facet_floats[1] = &facet.normal.y;
+  facet_floats[2] = &facet.normal.z;
+  facet_floats[3] = &facet.vertex[0].x;
+  facet_floats[4] = &facet.vertex[0].y;
+  facet_floats[5] = &facet.vertex[0].z;
+  facet_floats[6] = &facet.vertex[1].x;
+  facet_floats[7] = &facet.vertex[1].y;
+  facet_floats[8] = &facet.vertex[1].z;
+  facet_floats[9] = &facet.vertex[2].x;
+  facet_floats[10] = &facet.vertex[2].y;
+  facet_floats[11] = &facet.vertex[2].z;
 
   if (stl->error) return;
 

--- a/src/stlinit.c
+++ b/src/stlinit.c
@@ -20,13 +20,13 @@
  *           https://github.com/admesh/admesh/issues
  */
 
-#include <endian.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
 
+#include "portable_endian.h"
 #include "stl.h"
 
 #if !defined(SEEK_SET)


### PR DESCRIPTION
This PR fixes a deserialization issue (all floats end up wrong) that occurs when reading binary STLs on a big-endian machine, e.g. powerpc.