### PR TITLE
initialize the extra facet values to zero when loading

### DIFF
--- a/src/stlinit.c
+++ b/src/stlinit.c
@@ -261,6 +261,9 @@ stl_read(stl_file *stl, int first_facet, int first) {
   char facet_buffer[12 * sizeof(float)];
   uint32_t endianswap_buffer;  /* for byteswapping operations */
 
+  facet.extra[0] = 0;
+  facet.extra[1] = 0;
+
   facet_floats[0] = &facet.normal.x;
   facet_floats[1] = &facet.normal.y;
   facet_floats[2] = &facet.normal.z;


### PR DESCRIPTION
When loading an ASCII STL file, the facet extra values are set to random values.

This is because the facet is an uninitialized structure on the stack. During the load process of a binary STL, these values will be read correctly. But these values are skipped during the load process of an ASCII STL, leaving the uninitialized values untouched.

Situations where an ASCII STL is read, but a Binary STL is written would then result in different output across multiple runs.

An easy fix is to simply set the extra values to zero at the beginning of the load process. If the load is binary, that value will be overwritten for each facet. If the load is ASCII then the zero value can be correctly used for each facet.