### PR TITLE
Fix FreeBSD build

### DIFF
--- a/src/portable_endian.h
+++ b/src/portable_endian.h
@@ -54,6 +54,7 @@
 
 #	include <sys/endian.h>
 
+#if !defined(__FreeBSD__)
 #	define be16toh(x) betoh16(x)
 #	define le16toh(x) letoh16(x)
 
@@ -62,6 +63,7 @@
 
 #	define be64toh(x) betoh64(x)
 #	define le64toh(x) letoh64(x)
+#endif /*!defined(__FreeBSD__)*/
 
 #elif defined(__WINDOWS__)
 


### PR DESCRIPTION
FreeBSD already provides be16toh, le16toh, etc, so there's no need for that
definitions.

See [sys/endian.h](https://svnweb.freebsd.org/base/head/sys/sys/endian.h?view=markup)

This builds in FreeBSD {11.1,11.2,11.3}{i386,amd64} and 13-CURRENT amd64