### PR TITLE
Add new commands, 'translate-rel' and 'stretch'

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,7 +2,6 @@ name: Linux C/C++ CI
 
 on:
   push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/src/admesh.c
+++ b/src/admesh.c
@@ -23,7 +23,7 @@
 #include <stdio.h>
 #include <getopt.h>
 #include <stdlib.h>
-
+#include <string.h>
 
 #include "stl.h"
 #include "config.h"
@@ -43,6 +43,15 @@ main(int argc, char **argv) {
   float    rotate_x_angle = 0;
   float    rotate_y_angle = 0;
   float    rotate_z_angle = 0;
+  float    str_x_min = 0;
+  float    str_x_max = 0;
+  float    str_x     = 0;
+  float    str_y_min = 0;
+  float    str_y_max = 0;
+  float    str_y     = 0;
+  float    str_z_min = 0;
+  float    str_z_max = 0;
+  float    str_z     = 0;
   int      c;
   char     *program_name;
   char     *binary_name = NULL;
@@ -68,6 +77,7 @@ main(int argc, char **argv) {
   int      write_vrml_flag = 0;
   int      translate_flag = 0;
   int      translate_rel_flag = 0;
+  int      stretch_flag = 0;
   int      scale_versor_flag = 0;
   int      scale_flag = 0;
   int      rotate_x_flag = 0;
@@ -87,8 +97,8 @@ main(int argc, char **argv) {
   int ret = 0;
 
   enum {rotate_x = 1000, rotate_y, rotate_z, merge, help, version,
-        mirror_xy, mirror_yz, mirror_xz, scale, translate, translate_rel, reverse_all,
-        off_file, dxf_file, vrml_file, scale_xyz
+        mirror_xy, mirror_yz, mirror_xz, scale, translate, translate_rel,
+        stretch, reverse_all, off_file, dxf_file, vrml_file, scale_xyz
        };
 
   struct option long_options[] = {
@@ -110,6 +120,7 @@ main(int argc, char **argv) {
     {"write-vrml",         required_argument, NULL, vrml_file},
     {"translate",          required_argument, NULL, translate},
     {"translate-rel",      required_argument, NULL, translate_rel},
+    {"stretch",            required_argument, NULL, stretch},
     {"scale",              required_argument, NULL, scale},
     {"scale-xyz",          required_argument, NULL, scale_xyz},
     {"x-rotate",           required_argument, NULL, rotate_x},
@@ -201,6 +212,51 @@ main(int argc, char **argv) {
     case translate_rel:
       translate_rel_flag = 1;
       sscanf(optarg, "%f,%f,%f", &x_trans, &y_trans, &z_trans);
+      break;
+    case stretch:
+      stretch_flag = 1;
+      {
+        float *stretch_ptr[] = {&str_x_min, &str_x_max, &str_x , &str_y_min, &str_y_max, &str_y , &str_z_min, &str_z_max, &str_z};
+        int stretch_idx[10];
+        int optarg_idx;
+        int stretch_arg_cnt = 0;
+        stretch_idx[stretch_arg_cnt++] = -1;
+        for (optarg_idx = 0; optarg[optarg_idx]; optarg_idx++) {
+          if ((stretch_arg_cnt % 3 == 0) ? (optarg[optarg_idx] == ':') : (optarg[optarg_idx] == ',')) {
+            printf("Incorrect stretch arguments.\n");
+            usage(1, program_name);
+            return 1;
+          } else if ((optarg[optarg_idx] == ':') || (optarg[optarg_idx] == ',')) {
+            if (stretch_arg_cnt == 9) {
+              printf("Too many stretch arguments\n");
+              return 1;
+            }
+            stretch_idx[stretch_arg_cnt++] = optarg_idx;
+          }
+        }
+        stretch_idx[stretch_arg_cnt] = strlen(optarg);
+        if (!optarg[optarg_idx] && stretch_arg_cnt != 9) {
+          printf("Incorrect stretch arguments: %d.\n", stretch_arg_cnt);
+          usage(1, program_name);
+          return 1;
+        }
+        for (int i = 0; i < 9 ; i++) {
+          if (stretch_idx[i]+1 == stretch_idx[i+1]) {
+            switch (i % 3) {
+              case 0:
+                *stretch_ptr[i] = -1e39; // min value
+                break;
+              case 1:
+                *stretch_ptr[i] = 1e39; // max value
+                break;
+              case 2:
+                *stretch_ptr[i] = 0; // delta value
+            }
+          } else {
+              *stretch_ptr[i] = atof(optarg+stretch_idx[i]+1);
+          }
+        }
+      }
       break;
     case scale:
       scale_flag = 1;
@@ -309,6 +365,10 @@ redistribute it under certain conditions.  See the file COPYING for details.\n")
   if(translate_flag) {
     printf("Translating to %f, %f, %f ...\n", x_trans, y_trans, z_trans);
     stl_translate(&stl_in, x_trans, y_trans, z_trans);
+  }
+  if(stretch_flag) {
+    printf("Stretching: X: %f:%f:%f Y:%f:%f:%f Z: %f:%f:%f\n", str_x_min, str_x_max, str_x , str_y_min, str_y_max, str_y , str_z_min, str_z_max, str_z);
+    stl_stretch(&stl_in, str_x_min, str_x_max, str_x , str_y_min, str_y_max, str_y , str_z_min, str_z_max, str_z);
   }
   if(translate_rel_flag) {
     printf("Translating by %f, %f, %f ...\n", x_trans, y_trans, z_trans);
@@ -419,6 +479,7 @@ usage(int status, char *program_name) {
     printf("     --scale-xyz=x,y,z    Scale the file by a non uniform factor\n");
     printf("     --translate=x,y,z    Translate the file to x, y, and z\n");
     printf("     --translate-rel=x,y,z     Translate the file by x, y, and z\n");
+    printf("     --stretch=xmin:xmax:x,ymin:ymax:y,zmin:zmax:z     Translate the file by x, y, z but only within the given bounding box\n");
     printf("     --merge=name         Merge file called name with input file\n");
     printf(" -e, --exact              Only check for perfectly matched edges\n");
     printf(" -n, --nearby             Find and connect nearby facets. Correct bad facets\n");

--- a/src/admesh.c
+++ b/src/admesh.c
@@ -67,6 +67,7 @@ main(int argc, char **argv) {
   int      write_dxf_flag = 0;
   int      write_vrml_flag = 0;
   int      translate_flag = 0;
+  int      translate_rel_flag = 0;
   int      scale_versor_flag = 0;
   int      scale_flag = 0;
   int      rotate_x_flag = 0;
@@ -86,7 +87,7 @@ main(int argc, char **argv) {
   int ret = 0;
 
   enum {rotate_x = 1000, rotate_y, rotate_z, merge, help, version,
-        mirror_xy, mirror_yz, mirror_xz, scale, translate, reverse_all,
+        mirror_xy, mirror_yz, mirror_xz, scale, translate, translate_rel, reverse_all,
         off_file, dxf_file, vrml_file, scale_xyz
        };
 
@@ -108,6 +109,7 @@ main(int argc, char **argv) {
     {"write-dxf",          required_argument, NULL, dxf_file},
     {"write-vrml",         required_argument, NULL, vrml_file},
     {"translate",          required_argument, NULL, translate},
+    {"translate-rel",      required_argument, NULL, translate_rel},
     {"scale",              required_argument, NULL, scale},
     {"scale-xyz",          required_argument, NULL, scale_xyz},
     {"x-rotate",           required_argument, NULL, rotate_x},
@@ -194,6 +196,10 @@ main(int argc, char **argv) {
       break;
     case translate:
       translate_flag = 1;
+      sscanf(optarg, "%f,%f,%f", &x_trans, &y_trans, &z_trans);
+      break;
+    case translate_rel:
+      translate_rel_flag = 1;
       sscanf(optarg, "%f,%f,%f", &x_trans, &y_trans, &z_trans);
       break;
     case scale:
@@ -304,6 +310,10 @@ redistribute it under certain conditions.  See the file COPYING for details.\n")
     printf("Translating to %f, %f, %f ...\n", x_trans, y_trans, z_trans);
     stl_translate(&stl_in, x_trans, y_trans, z_trans);
   }
+  if(translate_rel_flag) {
+    printf("Translating by %f, %f, %f ...\n", x_trans, y_trans, z_trans);
+    stl_translate_relative(&stl_in, x_trans, y_trans, z_trans);
+  }
   if(merge_flag) {
     printf("Merging %s with %s\n", input_file, merge_name);
     /* Open the file and add the contents to stl_in: */
@@ -408,6 +418,7 @@ usage(int status, char *program_name) {
     printf("     --scale=factor       Scale the file by factor (multiply by factor)\n");
     printf("     --scale-xyz=x,y,z    Scale the file by a non uniform factor\n");
     printf("     --translate=x,y,z    Translate the file to x, y, and z\n");
+    printf("     --translate-rel=x,y,z     Translate the file by x, y, and z\n");
     printf("     --merge=name         Merge file called name with input file\n");
     printf(" -e, --exact              Only check for perfectly matched edges\n");
     printf(" -n, --nearby             Find and connect nearby facets. Correct bad facets\n");

--- a/src/admesh.c
+++ b/src/admesh.c
@@ -24,6 +24,7 @@
 #include <getopt.h>
 #include <stdlib.h>
 #include <string.h>
+#include <math.h>
 
 #include "stl.h"
 #include "config.h"
@@ -244,10 +245,10 @@ main(int argc, char **argv) {
           if (stretch_idx[i]+1 == stretch_idx[i+1]) {
             switch (i % 3) {
               case 0:
-                *stretch_ptr[i] = -1e39; // min value
+                *stretch_ptr[i] = -INFINITY; // min value
                 break;
               case 1:
-                *stretch_ptr[i] = 1e39; // max value
+                *stretch_ptr[i] = INFINITY; // max value
                 break;
               case 2:
                 *stretch_ptr[i] = 0; // delta value

--- a/src/stl.h
+++ b/src/stl.h
@@ -161,6 +161,7 @@ extern void stl_fix_normal_values(stl_file *stl);
 extern void stl_reverse_all_facets(stl_file *stl);
 extern void stl_translate(stl_file *stl, float x, float y, float z);
 extern void stl_translate_relative(stl_file *stl, float x, float y, float z);
+extern void stl_stretch(stl_file *stl, float x_min, float x_max, float x_off, float y_min, float y_max, float y_off, float z_min, float z_max, float z_off);
 extern void stl_scale_versor(stl_file *stl, float versor[3]);
 extern void stl_scale(stl_file *stl, float factor);
 extern void stl_rotate_x(stl_file *stl, float angle);

--- a/src/util.c
+++ b/src/util.c
@@ -122,6 +122,57 @@ stl_translate_relative(stl_file *stl, float x, float y, float z) {
   stl_invalidate_shared_vertices(stl);
 }
 
+/* stretch the STL, i.e. move a point by a relative XYZ offset if it fits within a given bounding box */
+void
+stl_stretch(stl_file *stl, float x_min, float x_max, float x_off, float y_min, float y_max, float y_off, float z_min, float z_max, float z_off) {
+  int i;
+  int j;
+
+  if (stl->error) return;
+
+  float min_x = stl->stats.min.x;
+  float min_y = stl->stats.min.y;
+  float min_z = stl->stats.min.z;
+  float max_x = stl->stats.max.x;
+  float max_y = stl->stats.max.y;
+  float max_z = stl->stats.max.z;
+
+  for(i = 0; i < stl->stats.number_of_facets; i++) {
+    for(j = 0; j < 3; j++) {
+      if (x_min < stl->facet_start[i].vertex[j].x &&
+          x_max > stl->facet_start[i].vertex[j].x &&
+          y_min < stl->facet_start[i].vertex[j].y &&
+          y_max > stl->facet_start[i].vertex[j].y &&
+          z_min < stl->facet_start[i].vertex[j].z &&
+          z_max > stl->facet_start[i].vertex[j].z) {
+        stl->facet_start[i].vertex[j].x += x_off;
+        stl->facet_start[i].vertex[j].y += y_off;
+        stl->facet_start[i].vertex[j].z += z_off;
+        if (stl->facet_start[i].vertex[j].x < min_x)
+          min_x = stl->facet_start[i].vertex[j].x;
+        if (stl->facet_start[i].vertex[j].x > max_x)
+          max_x = stl->facet_start[i].vertex[j].x;
+        if (stl->facet_start[i].vertex[j].y < min_y)
+          min_y = stl->facet_start[i].vertex[j].y;
+        if (stl->facet_start[i].vertex[j].y > max_y)
+          max_y = stl->facet_start[i].vertex[j].y;
+        if (stl->facet_start[i].vertex[j].z < min_z)
+          min_z = stl->facet_start[i].vertex[j].z;
+        if (stl->facet_start[i].vertex[j].z > max_z)
+          max_z = stl->facet_start[i].vertex[j].z;
+      }
+    }
+  }
+  stl->stats.min.x = min_x;
+  stl->stats.min.y = min_y;
+  stl->stats.min.z = min_z;
+  stl->stats.max.x = max_x;
+  stl->stats.max.y = max_y;
+  stl->stats.max.z = max_z;
+
+  stl_invalidate_shared_vertices(stl);
+}
+
 void
 stl_scale_versor(stl_file *stl, float versor[3]) {
   int i;


### PR DESCRIPTION
The 'translate-rel' command simple translate the object by the given x,y,z offset instead of setting an absolute point.
The 'stretch' command is used to translate only some of the points, constrained by a box. This is useful for changing the dimensions of the STL, or parts of it.
